### PR TITLE
Github file structure fixed

### DIFF
--- a/.scrum/scrumPlaceholder.txt
+++ b/.scrum/scrumPlaceholder.txt
@@ -1,0 +1,1 @@
+Do not delete until the parent directory has other files in it

--- a/src/controllers/controllerPlaceholder.txt
+++ b/src/controllers/controllerPlaceholder.txt
@@ -1,0 +1,1 @@
+Do not delete until the parent directory has other files in it

--- a/src/models/modelPlaceholder.txt
+++ b/src/models/modelPlaceholder.txt
@@ -1,0 +1,1 @@
+Do not delete until the parent directory has other files in it

--- a/src/services/servicePlaceholder.txt
+++ b/src/services/servicePlaceholder.txt
@@ -1,0 +1,1 @@
+Do not delete until the parent directory has other files in it

--- a/src/utils/utilsPlaceholder.txt
+++ b/src/utils/utilsPlaceholder.txt
@@ -1,0 +1,1 @@
+Do not delete until the parent directory has other files in it

--- a/src/views/viewPlaceholder.txt
+++ b/src/views/viewPlaceholder.txt
@@ -1,0 +1,1 @@
+Do not delete until the parent directory has other files in it

--- a/tests/testPlaceholder.txt
+++ b/tests/testPlaceholder.txt
@@ -1,0 +1,1 @@
+Do not delete until the parent directory has other files in it


### PR DESCRIPTION
The problem where no empty folders showed is now solved. There are empty placeholder.txt files in all empty folders so that they appear on GitHub. 

**These can be deleted once there exists other files in the parent folder**