### PR TITLE
Order Cancellation (status check + update)

### DIFF
--- a/src/backend/controllers/order_controller.py
+++ b/src/backend/controllers/order_controller.py
@@ -29,3 +29,27 @@ class OrderController:
             raise HTTPException(status_code=404, detail=f"Order {order_id} not found")
         return order
 
+    def cancel_order(self, order_id: int):
+        order = self.order_repo.get_order_by_id(order_id) # Get order from repo
+        if order == None:
+            raise HTTPException(status_code=404, detail=f"Order {order_id} not found")
+        
+        status = str(order.get("status", " ")).strip().lower() # Make Status into a uniformed format to compare
+
+        # If the status are in these status, then the order can't be cancelled
+        locked_statuses = ["payment confirmed", "preparing", "out for delivery", "delivered"]
+        
+        if status in locked_statuses:
+            raise HTTPException(status_code=403, detail=f"Order is already being prepared and cannot be cancelled")
+        if status in ["cancelled"]:
+            return order
+        
+        # update the order to cancelled
+        updated = self.order_repo.update_order_status(order_id, {"status": "cancelled"})
+
+        # If the update return error, then make it HTTPException
+        if isinstance(updated, dict) and "error" in updated:
+            raise HTTPException(status_code=404, detail=f"error")
+        
+        # return updated order
+        return updated

--- a/src/backend/repositories/order_repo.py
+++ b/src/backend/repositories/order_repo.py
@@ -91,3 +91,25 @@ class OrderRepository:
         except KeyError as e:
             return {"error": f"Order missing id field: {e}"}
     
+    def cancel_order(self, order_id: int) -> dict:
+        try:
+            with open(self.file_path, 'r') as f:
+                data = json.load(f)
+            for i, order in enumerate(data):
+                if order.get["id"] == order_id:
+
+                    data[i] = {**order, **updates} # update the order with the new status
+                    with open(self.file_path, 'w') as f:
+                        json.dump(data, f, indent=4)
+                    
+                    return data[i]
+                
+                return{"error": f"Order with id {order_id} not found."}
+            
+        except FileNotFoundError:
+            return {"error": f"File {self.file_path} not found."}
+        except json.JSONDecodeError as e:
+            return {"error": f"Error decoding JSON: {e}"}
+        
+        
+                    

--- a/src/backend/routers/order.py
+++ b/src/backend/routers/order.py
@@ -26,6 +26,9 @@ def delete_order(order_id: int, controller: OrderController = Depends(get_contro
 def get_order(order_id: int, controller: OrderController = Depends(get_controller)):
     return controller.get_order(order_id)
 
+@router.post("/{order_id}/cancel", response_model=Order)
+def cancel_order(order_id: int, controller: OrderController = Depends(get_controller)):
+    return controller.cancel_order(order_id)
 '''
 @router.delete("/{order_id}/order/{order_item_id}", response_model=OrderItem)
 def delete_order_item(order_id: int, order_item_id: int, controller: OrderController = Depends(get_controller)):


### PR DESCRIPTION
What's changed

Added `cancel_order()` logic in the order controller
Added `update_order()` in the order repo to update an order in the JSON file (sets `status = "cancelled"` instead of deleting)
Edit the order 

Orders can only be cancelled if they are before the “locked” stages. (after payment confirmed)
If the order status is payment confirmed or later cancellation is blocked.


`404` if the order id doesn’t exist
`403` if the order is already locked (too late to cancel)
Repo-level errors are handled for:

 missing orders file (`FileNotFoundError`)
 bad/corrupted JSON (`JSONDecodeError`)


**Not tested yet — requesting review for logic + status rule**
* I noticed we have two order model files (`order.py` and `orders.py`). Current imports seem to use `order.py` (no “s”). If we’re supposed to use `orders.py` instead, I can update the cancellation code to match and we should clean up the duplicate model.
