### PR TITLE
Order modification & Cancellation and Allowing Order Modification

### DIFF
--- a/src/backend/controllers/order_controller.py
+++ b/src/backend/controllers/order_controller.py
@@ -54,14 +54,16 @@ class OrderController:
     '''
     The idea here is that we pass the whole menu item and we create an order item from that menu item (basically so they have the same id - easier to recognize same items that way)
     Inside the repo we assign the item price/subtotal and the order id itself.
+
+    Order item inherited from menu item
     '''
-    def add_order_item_to_order(self, menu_item: MenuItem, order_id: int):
+    def add_order_item_to_order(self, menu_item: MenuItem, order_id: int, quantity: int):
         order = self.get_order(order_id)
         # Checking if order should be able to be modified or not
         if not (order["status"] == "out for delivery" or order["status"] == "delivered"):
 
             # Creating order item based on menu item
-            order_item = OrderItemCreate(item_id = menu_item.id, quantity = 1)
+            order_item = OrderItemCreate(item_id = menu_item.id, quantity = quantity)
             if isinstance(order, dict) and "error" in order:
                 raise HTTPException(status_code=404, detail=order["error"])
             

--- a/src/backend/models/order.py
+++ b/src/backend/models/order.py
@@ -21,11 +21,6 @@ class OrderBase(BaseModel):
     tax: float
 
 class OrderCreate(OrderBase):
-    customer_id: int
-    restaurant_id: int
-    status: OrderStatus
-    total_price: float
-    tax: float
     order_items: Optional[List[OrderItem]] = None
 
 class Order(OrderBase):

--- a/src/backend/models/order_item.py
+++ b/src/backend/models/order_item.py
@@ -1,4 +1,5 @@
 from pydantic import BaseModel, Field
+#from src.backend.models.menu_item import MenuItem
 
 class OrderItemBase(BaseModel):
     item_id: int

--- a/src/backend/repositories/order_repo.py
+++ b/src/backend/repositories/order_repo.py
@@ -1,6 +1,7 @@
 import json
 from typing import List, Optional, Dict
 from datetime import datetime
+from fastapi import HTTPException
 
 class OrderRepository:
     ORDER_FILE = 'data/order.json'
@@ -26,11 +27,11 @@ class OrderRepository:
                 return order
                     
         except FileNotFoundError:
-            return {"error": f"File {self.file_path} not found."}
+            raise HTTPException(status_code=404, detail=f"File {self.file_path} not found.")
         except json.JSONDecodeError as e:
-            return {"error": f"Error decoding JSON: {e}"}
+            raise HTTPException(status_code=500, detail=f"Error decoding JSON: {e}")
         except KeyError as e:
-            return {"error": f"Order missing id field: {e}"}
+            raise HTTPException(status_code=500, detail=f"Order missing id field: {e}")
     
 
     def create_order(self, order_data: dict) -> dict:
@@ -57,9 +58,9 @@ class OrderRepository:
                 json.dump([order_data], f, indent=4)
             return order_data
         except json.JSONDecodeError as e:
-            return {"error": f"Error decoding JSON: {e}"}
+            raise HTTPException(status_code=500, detail=f"Error decoding JSON: {e}")
         except KeyError as e:
-            return {"error": f"Order missing id field: {e}"}
+            raise HTTPException(status_code=500, detail=f"Order missing id field: {e}")
     
     def delete_order(self, order_id: int) -> dict:
         try:
@@ -76,7 +77,7 @@ class OrderRepository:
                 
                 # If nothing is found
                 if deleted_order == None:
-                    return {"error": f"Order with id {order_id} not found."}
+                    raise HTTPException(status_code=404, detail=f"Order with id {order_id} not found.")
                 
                 # Saving changes
                 with open(self.file_path, 'w') as f:
@@ -84,11 +85,11 @@ class OrderRepository:
 
                 return deleted_order
         except FileNotFoundError:
-            return {"error": f"File {self.file_path} not found."}
+            raise HTTPException(status_code=404, detail=f"File {self.file_path} not found.")
         except json.JSONDecodeError as e:
-            return {"error": f"Error decoding JSON: {e}"}
+            raise HTTPException(status_code=500, detail=f"Error decoding JSON: {e}")
         except KeyError as e:
-            return {"error": f"Order missing id field: {e}"}
+            raise HTTPException(status_code=500, detail=f"Order missing id field: {e}")
     
     def update_order_status(self, order_id: int, order_status: str) -> Optional[dict]:
         with open(self.file_path, 'r') as j:
@@ -115,33 +116,38 @@ class OrderRepository:
                         # Look if the order item already exists in order items (find the first match)
                         order_item = next(filter(lambda item: item["item_id"] == item_data["item_id"], order_items), None)
 
-                        # Adding remaining item fields to order item
+                        # Adding order_id field to order item
                         item_data["order_id"] = order_id
-                        item_data["subtotal"] = price
 
                         # If nothing is found, add new item. Else: increase item quantity
                         if order_item == None:
+                            # Adding subtotal field to order item
+                            item_data["subtotal"] = price * item_data["quantity"]
+
                             order_items.append(item_data)
                             order['order_items'] = order_items
                         else:
                             order_item["quantity"] += item_data["quantity"]
+                            
+                            # Adding subtotal field to order item
+                            item_data["subtotal"] = price * order_item["quantity"]
 
                         flag = False
                         break
                 
                 # Ensure a correct error message appears if order id is not found
                 if flag:
-                    return {"error": f"Order id {order_id} not found."}
+                    raise HTTPException(status_code=404, detail=f"Order with id {order_id} not found.")
                 
                 with open(self.file_path, 'w') as f:
                     json.dump(data, f, indent=4)
                 return order_item if order_item != None else item_data
         except FileNotFoundError:
-            return {"error": f"File {self.file_path} not found."}
+            raise HTTPException(status_code=404, detail=f"File {self.file_path} not found.")
         except json.JSONDecodeError as e:
-            return {"error": f"Error decoding JSON: {e}"}
+            raise HTTPException(status_code=500, detail=f"Error decoding JSON: {e}")
         except KeyError as e:
-            return {"error": f"Order item missing id field: {e}"}
+            raise HTTPException(status_code=500, detail=f"Order item missing id field: {e}")
         
     def delete_order_item_from_order(self, order_id: int, order_item_id: int) -> dict:
         try:
@@ -170,7 +176,7 @@ class OrderRepository:
                         
                         # Ensure a correct error message appears if order item id is not found
                         if deleted_item == None:
-                            return {"error": f"Order item with id {order_item_id} not found."}
+                            raise HTTPException(status_code=404, detail=f"Order item with id {order_item_id} not found.")
                         
                         order["order_items"] = new_order_items
                         
@@ -180,14 +186,14 @@ class OrderRepository:
                 
                 # Ensure a correct error message appears if order id is not found
                 if flag:
-                    return {"error": f"Order id {order_id} not found."}
+                    raise HTTPException(status_code=404, detail=f"Order with id {order_id} not found.")
                 
         except FileNotFoundError:
-            return {"error": f"File {self.file_path} not found."}
+            raise HTTPException(status_code=404, detail=f"File {self.file_path} not found.")
         except json.JSONDecodeError as e:
-            return {"error": f"Error decoding JSON: {e}"}
+            raise HTTPException(status_code=500, detail=f"Error decoding JSON: {e}")
         except KeyError as e:
-            return {"error": f"Order item missing id field: {e}"}
+            raise HTTPException(status_code=500, detail=f"Order item missing id field: {e}")
         
     def get_order_items_from_order(self, order_id: int) -> List[dict]:
         try:
@@ -196,12 +202,12 @@ class OrderRepository:
                 for order in data:
                     if order['id'] == order_id:
                         return order.get('order_items', [])
-                return {"error": f"Order id {order_id} not found."}
+                raise HTTPException(status_code=404, detail=f"Order with id {order_id} not found.")
             
         except FileNotFoundError:
-            return {"error": f"File {self.file_path} not found."}
+            raise HTTPException(status_code=404, detail=f"File {self.file_path} not found.")
         except json.JSONDecodeError as e:
-            return {"error": f"Error decoding JSON: {e}"}
+            raise HTTPException(status_code=500, detail=f"Error decoding JSON: {e}")
         except KeyError as e:
-            return {"error": f"Order missing id field: {e}"}
+            raise HTTPException(status_code=500, detail=f"Order item missing id field: {e}")
                     

--- a/src/backend/routers/order.py
+++ b/src/backend/routers/order.py
@@ -37,8 +37,8 @@ def delete_order_item(order_id: int, item_id: int, controller: OrderController =
     return deleted_item
 
 @router.post("/{order_id}/items", response_model=OrderItem)
-def add_order_item(order_id: int, order_item: MenuItem, controller: OrderController = Depends(get_controller)):
-    new_item = controller.add_order_item_to_order(order_item, order_id)
+def add_order_item(order_id: int, order_item: MenuItem, quantity: int, controller: OrderController = Depends(get_controller)):
+    new_item = controller.add_order_item_to_order(order_item, order_id, quantity)
     return new_item
 
 @router.get("/{order_id}/items", response_model=List[OrderItem])

--- a/tests/order_test.py
+++ b/tests/order_test.py
@@ -59,34 +59,44 @@ def test_add_order(test_client):
 
 def test_delete_order(test_client):
     response = test_client.post("/order/", json=new_order)
-    response2 = test_client.post("/order/", json=new_order_2)
-    response3 = test_client.post("/order/", json=new_order_3)
 
     assert response.status_code == 200
-    assert response2.status_code == 200
-    assert response3.status_code == 200
 
     order_id = response.json()["id"]
-    order_id_2 = response2.json()["id"]
-    order_id_3 = response3.json()["id"]
 
     # Delete order
     delete_response = test_client.delete(f"/order/{order_id}")
     assert delete_response.status_code == 200
 
-    # Try to delete order when order status = preparing
-    delete_response_2 = test_client.delete(f"/order/{order_id_2}")
-    assert delete_response_2.status_code == 200
-
-    # Try to delete order when order status = out for delivery
-    delete_response_3 = test_client.delete(f"/order/{order_id_3}")
-    assert delete_response_3.status_code == 403
-
     # After deletion, trying to get the order should return a 404
     get_response = test_client.get(f"/order/{order_id}")
     assert get_response.status_code == 404
-    get_response_2 = test_client.get(f"/order/{order_id_2}")
-    assert get_response_2.status_code == 404
+
+def test_delete_order_preparing(test_client):
+    response = test_client.post("/order/", json=new_order_2)
+
+    assert response.status_code == 200
+
+    order_id = response.json()["id"]
+
+    # Try to delete order when order status = out for delivery
+    delete_response = test_client.delete(f"/order/{order_id}")
+    assert delete_response.status_code == 200
+
+    # After deletion, trying to get the order should return a 404
+    get_response = test_client.get(f"/order/{order_id}")
+    assert get_response.status_code == 404    
+
+def test_delete_order_out_for_delivery(test_client):
+    response = test_client.post("/order/", json=new_order_3)
+
+    assert response.status_code == 200
+
+    order_id = response.json()["id"]
+
+    # Try to delete order when order status = out for delivery
+    delete_response = test_client.delete(f"/order/{order_id}")
+    assert delete_response.status_code == 403
 
     '''
     Order item tests:
@@ -120,12 +130,12 @@ def test_add_order_item_to_order(test_client):
     order_id = response.json()["id"]
 
     # Now try to add an order item to that order
-    add_response = test_client.post(f"/order/{order_id}/items", json=menu_item)
+    add_response = test_client.post(f"/order/{order_id}/items", params={"quantity": 2}, json=menu_item)
     assert add_response.status_code == 200
     data = add_response.json()
     assert data["item_id"] == menu_item["id"]
-    assert data["quantity"] == 1
-    assert data["subtotal"] == 9.99
+    assert data["quantity"] == 2
+    assert data["subtotal"] == 9.99*2
 
 def test_delete_order_item_from_order(test_client):
     # First add an order and an order item to ensure there is something to delete
@@ -133,7 +143,7 @@ def test_delete_order_item_from_order(test_client):
     assert response.status_code == 200
     order_id = response.json()["id"]
 
-    add_response = test_client.post(f"/order/{order_id}/items", json=menu_item)
+    add_response = test_client.post(f"/order/{order_id}/items", params={"quantity": 1}, json=menu_item)
     assert add_response.status_code == 200
     item_id = add_response.json()["item_id"]
 
@@ -151,7 +161,7 @@ def test_update_order_item_from_order(test_client):
     assert response.status_code == 200
     order_id = response.json()["id"]
 
-    add_response = test_client.post(f"/order/{order_id}/items", json=menu_item)
+    add_response = test_client.post(f"/order/{order_id}/items", params={"quantity": 1}, json=menu_item)
     assert add_response.status_code == 200
     item_id = add_response.json()["item_id"]
 
@@ -160,7 +170,7 @@ def test_update_order_item_from_order(test_client):
     assert data["quantity"] == 1
 
     # Now try to update that order item (increment one item already existent in that order)
-    add_response_2 = test_client.post(f"/order/{order_id}/items", json=menu_item)
+    add_response_2 = test_client.post(f"/order/{order_id}/items", params={"quantity": 1}, json=menu_item)
     assert add_response_2.status_code == 200
     data_2 = add_response_2.json()
     assert data_2["item_id"] == menu_item["id"]


### PR DESCRIPTION
This PR have several changes:
- Prevent users from modifying orders that are already out for delivery
- Allow users to cancel or modify orders before they are sent for delivery
- Implement endpoints to add and remove items from an order
- Support incrementing/decrementing item quantities when adding or removing the same menu item
- Add GET endpoints to retrieve order items by order ID or item ID
- Add unit tests for all newly introduced functionality